### PR TITLE
add trust points leaderboard

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -1,0 +1,99 @@
+const User = require('../models/User');
+const Item = require('../models/Item');
+const ChatRoom = require('../models/ChatRoom');
+
+// Get leaderboard
+exports.getLeaderboard = async (req, res) => {
+  try {
+    const { time } = req.query;
+    let dateFilter = {};
+    
+    // Apply time filter
+    if (time === 'week') {
+      const weekAgo = new Date();
+      weekAgo.setDate(weekAgo.getDate() - 7);
+      dateFilter = { createdAt: { $gte: weekAgo } };
+    } else if (time === 'month') {
+      const monthAgo = new Date();
+      monthAgo.setMonth(monthAgo.getMonth() - 1);
+      dateFilter = { createdAt: { $gte: monthAgo } };
+    }
+    
+    // Get top 50 users by trust score
+    const users = await User.find({ role: 'user' })
+      .sort({ trustScore: -1 })
+      .limit(50)
+      .select('nickname realName trustScore');
+    
+    // For each user, get additional stats
+    const usersWithStats = await Promise.all(users.map(async (user) => {
+      // Count items found (found items that were returned)
+      const itemsFound = await Item.countDocuments({ 
+        postedBy: user._id, 
+        type: 'found',
+        status: 'returned'
+      });
+      
+      // Count items lost (lost items that were returned)
+      const itemsLost = await Item.countDocuments({ 
+        postedBy: user._id, 
+        type: 'lost',
+        status: 'returned'
+      });
+      
+      // Count successful handovers
+      const successfulHandovers = await ChatRoom.countDocuments({
+        'participants.userId': user._id,
+        status: 'closed'
+      });
+      
+      return {
+        ...user.toObject(),
+        itemsFound,
+        itemsLost,
+        itemsReturned: itemsFound + itemsLost,
+        successfulHandovers
+      };
+    }));
+    
+    res.json({ success: true, users: usersWithStats });
+  } catch (error) {
+    console.error('❌ Get leaderboard error:', error);
+    res.status(500).json({ message: 'Failed to get leaderboard' });
+  }
+};
+
+// Get user profile (optional)
+exports.getUserProfile = async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id).select('-password');
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    res.json({ success: true, user });
+  } catch (error) {
+    console.error('❌ Get profile error:', error);
+    res.status(500).json({ message: 'Failed to get profile' });
+  }
+};
+
+// Update user profile (optional)
+exports.updateUserProfile = async (req, res) => {
+  try {
+    const { nickname } = req.body;
+    
+    const user = await User.findById(req.user.id);
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    
+    if (nickname) user.nickname = nickname;
+    
+    await user.save();
+    
+    res.json({ success: true, user: { ...user.toObject(), password: undefined } });
+  } catch (error) {
+    console.error('❌ Update profile error:', error);
+    res.status(500).json({ message: 'Failed to update profile' });
+  }
+};

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+const { protect } = require('../middleware/authMiddleware');
+const { 
+  getLeaderboard, 
+  getUserProfile, 
+  updateUserProfile 
+} = require('../controllers/userController');
+
+// Protect all routes
+router.use(protect);
+
+// Leaderboard routes
+router.get('/leaderboard', getLeaderboard);
+
+// User profile routes
+router.get('/profile', getUserProfile);
+router.put('/profile', updateUserProfile);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -28,6 +28,7 @@ const adminRoutes = require('./routes/adminRoutes');
 const contactRoutes = require('./routes/contactRoutes');
 const chatRoutes = require('./routes/chatRoutes');
 const notificationRoutes = require('./routes/notificationRoutes');
+const userRoutes = require('./routes/userRoutes'); // 🆕 ADDED
 const CommunityEvent = require('./models/CommunityEvent');
 const { enrichEvent, splitUpcomingFinished } = require('./utils/communityEventStatus');
 const eventPollController = require('./controllers/eventPollController');
@@ -38,6 +39,7 @@ app.use('/api/admin', adminRoutes);
 app.use('/api/contacts', contactRoutes);
 app.use('/api/chat', chatRoutes);
 app.use('/api/notifications', notificationRoutes);
+app.use('/api/users', userRoutes); // 🆕 ADDED
 
 app.get('/api/community-events', async (req, res) => {
   try {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,7 @@ import ProtectedAdminRoute from './ProtectedAdminRoute';
 import ItemDetailPage from './ItemDetailPage';
 import ContactUs from './ContactUs';
 import AboutUs from './AboutUs';
+import Leaderboard from './Leaderboard'; // 🆕 ADDED
 
 // 🆕 NEW CHAT COMPONENTS
 import MyChats from './MyChats';
@@ -59,6 +60,9 @@ function App() {
 
           {/* The Main Application Dashboard */}
           <Route path="/dashboard" element={<Dashboard />} />
+
+          {/* Leaderboard */}
+          <Route path="/leaderboard" element={<Leaderboard />} />
 
           {/* 🆕 CHAT ROUTES */}
           <Route path="/chats" element={<MyChats />} />

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -399,7 +399,13 @@ const Dashboard = () => {
           >
             About Us
           </button>
-          
+          {/* 🆕 Leaderboard Button */}
+          <button
+            onClick={() => navigate('/leaderboard')}
+            className="text-gray-600 font-medium transition hover:text-blue-600 dark:text-slate-300 dark:hover:text-blue-400 flex items-center gap-1"
+          >
+            🏆 Leaderboard
+          </button>
           {/* Chats Button */}
           <button
             onClick={() => navigate('/chats')}

--- a/frontend/src/Leaderboard.js
+++ b/frontend/src/Leaderboard.js
@@ -1,0 +1,219 @@
+import React, { useState, useEffect } from 'react';
+import { Trophy, Award, Medal, Crown, Star, TrendingUp, Loader, ArrowLeft } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+const Leaderboard = () => {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [timeFrame, setTimeFrame] = useState('all');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetchLeaderboard();
+  }, [timeFrame]);
+
+  const fetchLeaderboard = async () => {
+    try {
+      setLoading(true);
+      const token = localStorage.getItem('resqToken');
+      const response = await fetch(`/api/users/leaderboard?time=${timeFrame}`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await response.json();
+      if (data.success) {
+        setUsers(data.users);
+      }
+    } catch (error) {
+      console.error('Failed to fetch leaderboard:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getRankIcon = (index) => {
+    if (index === 0) return <Trophy className="w-8 h-8 text-yellow-500" />;
+    if (index === 1) return <Award className="w-7 h-7 text-gray-400" />;
+    if (index === 2) return <Medal className="w-7 h-7 text-amber-600" />;
+    return <span className="w-6 h-6 flex items-center justify-center font-bold text-gray-400">{index + 1}</span>;
+  };
+
+  const getGradient = (index) => {
+    if (index === 0) return 'from-yellow-500 to-orange-500';
+    if (index === 1) return 'from-gray-400 to-gray-500';
+    if (index === 2) return 'from-amber-600 to-amber-700';
+    return 'from-blue-500 to-purple-500';
+  };
+
+  const getRankBadge = (index) => {
+    if (index === 0) return '👑 Champion';
+    if (index === 1) return '🥈 Runner Up';
+    if (index === 2) return '🥉 Third Place';
+    return `#${index + 1}`;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <Loader className="w-8 h-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
+      <div className="max-w-4xl mx-auto px-4">
+        {/* 🆕 Back Button */}
+        <button
+          onClick={() => navigate('/dashboard')}
+          className="mb-6 flex items-center gap-2 text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition"
+        >
+          <ArrowLeft className="w-5 h-5" />
+          Back to Dashboard
+        </button>
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center gap-2 bg-gradient-to-r from-yellow-500 to-orange-500 text-white px-6 py-3 rounded-full shadow-lg mb-4">
+            <Trophy className="w-6 h-6" />
+            <span className="font-bold text-lg">Trust Leaderboard</span>
+          </div>
+          <h1 className="text-3xl font-bold text-gray-800 dark:text-white">Top Helpers</h1>
+          <p className="text-gray-500 dark:text-gray-400 mt-2">
+            Students who helped return the most items
+          </p>
+        </div>
+
+        {/* Time Filter */}
+        <div className="flex justify-center gap-3 mb-8">
+          <button
+            onClick={() => setTimeFrame('all')}
+            className={`px-4 py-2 rounded-full text-sm font-medium transition ${
+              timeFrame === 'all' 
+                ? 'bg-green-600 text-white' 
+                : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
+            }`}
+          >
+            All Time
+          </button>
+          <button
+            onClick={() => setTimeFrame('week')}
+            className={`px-4 py-2 rounded-full text-sm font-medium transition ${
+              timeFrame === 'week' 
+                ? 'bg-green-600 text-white' 
+                : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
+            }`}
+          >
+            This Week
+          </button>
+          <button
+            onClick={() => setTimeFrame('month')}
+            className={`px-4 py-2 rounded-full text-sm font-medium transition ${
+              timeFrame === 'month' 
+                ? 'bg-green-600 text-white' 
+                : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
+            }`}
+          >
+            This Month
+          </button>
+        </div>
+
+        {/* Leaderboard List */}
+        {users.length === 0 ? (
+          <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-xl shadow-md">
+            <Trophy className="w-16 h-16 text-gray-300 mx-auto mb-4" />
+            <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-300">No data yet</h3>
+            <p className="text-gray-500 dark:text-gray-400 mt-2">
+              Start helping others to appear on the leaderboard!
+            </p>
+            <button
+              onClick={() => navigate('/dashboard')}
+              className="mt-6 px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition"
+            >
+              Browse Items
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {users.map((user, index) => (
+              <div
+                key={user._id}
+                className={`bg-gradient-to-r ${getGradient(index)} rounded-xl p-5 text-white shadow-lg transform transition hover:scale-102 hover:shadow-xl`}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-4">
+                    <div className="flex-shrink-0">
+                      {getRankIcon(index)}
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <p className="font-bold text-lg">{user.nickname || user.realName}</p>
+                        {index === 0 && <Crown className="w-4 h-4 text-yellow-300" />}
+                      </div>
+                      <div className="flex items-center gap-3 mt-1">
+                        <span className="text-sm opacity-90">
+                          {getRankBadge(index)}
+                        </span>
+                        <span className="text-xs opacity-75 flex items-center gap-1">
+                          <Star className="w-3 h-3" />
+                          {user.itemsReturned || 0} items returned
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-3xl font-bold">{user.trustScore || 0}</p>
+                    <p className="text-xs opacity-75">points</p>
+                  </div>
+                </div>
+                
+                {/* Progress Bar */}
+                <div className="mt-3">
+                  <div className="w-full bg-white/30 rounded-full h-2">
+                    <div
+                      className="bg-white h-2 rounded-full transition-all"
+                      style={{ width: `${Math.min(((user.trustScore || 0) / 500) * 100, 100)}%` }}
+                    />
+                  </div>
+                </div>
+                
+                {/* Stats */}
+                <div className="flex justify-between mt-3 text-xs opacity-75">
+                  <span>📦 {user.itemsFound || 0} found</span>
+                  <span>🔍 {user.itemsLost || 0} lost</span>
+                  <span>✅ {user.successfulHandovers || 0} handovers</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        
+        {/* Info Card */}
+        <div className="mt-8 bg-white dark:bg-gray-800 rounded-xl p-5 shadow-md border border-gray-100 dark:border-gray-700">
+          <div className="flex items-center gap-3 mb-3">
+            <TrendingUp className="w-5 h-5 text-green-600" />
+            <h3 className="font-semibold text-gray-800 dark:text-white">How to earn points?</h3>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+            <div className="flex items-center gap-2">
+              <span className="w-6 h-6 bg-green-100 text-green-600 rounded-full flex items-center justify-center text-xs font-bold">1</span>
+              <span className="text-gray-600 dark:text-gray-300">Report a found item</span>
+              <span className="text-green-600 font-bold ml-auto">+10</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="w-6 h-6 bg-green-100 text-green-600 rounded-full flex items-center justify-center text-xs font-bold">2</span>
+              <span className="text-gray-600 dark:text-gray-300">Successfully return item (OTP)</span>
+              <span className="text-green-600 font-bold ml-auto">+50</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="w-6 h-6 bg-green-100 text-green-600 rounded-full flex items-center justify-center text-xs font-bold">3</span>
+              <span className="text-gray-600 dark:text-gray-300">Help others in chat</span>
+              <span className="text-green-600 font-bold ml-auto">+5</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Leaderboard;


### PR DESCRIPTION
Add Trust Points Leaderboard

- Create leaderboard page displaying top helpers ranked by trust score
- Add time filters (All Time / Week / Month) for dynamic ranking
- Display user nicknames, trust points, items found/lost, and successful handovers
- Implement gradient cards with rank icons (🥇 🥈 🥉)
- Add progress bars showing points progress
- Include back navigation button to dashboard
- Create backend API endpoint /api/users/leaderboard
- Add leaderboard button to dashboard navbar